### PR TITLE
Include missing functional header

### DIFF
--- a/lib/samplecache.hh
+++ b/lib/samplecache.hh
@@ -4,6 +4,7 @@
 #define LIQUIDSFZ_SAMPLECACHE_HH
 
 #include <vector>
+#include <functional>
 #include <map>
 #include <memory>
 #include <algorithm>


### PR DESCRIPTION
lib/samplecache.hh:
Include the functional header, as without it the build fails on gcc >=
12.