### PR TITLE
select sfz files with a user defined script instead of a dialog box

### DIFF
--- a/lv2/lv2ui.cc
+++ b/lv2/lv2ui.cc
@@ -38,6 +38,7 @@ class FileDialog
   constexpr static auto KDIALOG = "/usr/bin/kdialog";
   constexpr static auto YAD     = "/usr/bin/yad";
   constexpr static auto ZENITY  = "/usr/bin/zenity";
+  constexpr static auto USRSCRIPT  = "/usr/local/bin/sfzselect";
 
   static inline string     last_start_dir;
   static inline std::mutex last_start_dir_mutex;
@@ -70,7 +71,7 @@ public:
 bool
 FileDialog::have_helpers()
 {
-  return fs::exists (KDIALOG) || fs::exists (YAD) || fs::exists (ZENITY);
+  return fs::exists (KDIALOG) || fs::exists (YAD) || fs::exists (ZENITY) || fs::exists (USRSCRIPT);
 }
 
 bool
@@ -87,9 +88,9 @@ FileDialog::FileDialog (const string& title, const string& filter, const string&
   vector<string> dialog_helpers;
 
   if (is_kde_full_session())
-    dialog_helpers = { KDIALOG, ZENITY, YAD };
+    dialog_helpers = { USRSCRIPT, KDIALOG, ZENITY, YAD };
   else
-    dialog_helpers = { ZENITY, YAD, KDIALOG };
+    dialog_helpers = { USRSCRIPT,  ZENITY, YAD, KDIALOG };
 
   for (auto d : dialog_helpers)
     {
@@ -138,6 +139,7 @@ FileDialog::FileDialog (const string& title, const string& filter, const string&
       close (pipe_fds[1]);
 
       vector<string> args;
+      if (dialog_type == USRSCRIPT) args = { USRSCRIPT };
       if (dialog_type == KDIALOG)
         {
           args = { KDIALOG, "--getopenfilename", "--title", title, get_last_start_dir() };


### PR DESCRIPTION
Hi,

I like liquidsfz but I hate having to use zenitty to select a file, because : 
1. I find it horribly frustrating to use
2. It installs tons of dependencies

Fortunately it prints the selected file name to stdin, just like dmenu/rofi/fzf, which I use a lot, So I added a few lines to `lv2ui.cc` to use a user defined script, located in `/usr/local/bin/sfzselect`.

Here is a quick video to show how it goes : 
[liquidsfz.webm](https://github.com/user-attachments/assets/c10f2d88-77a2-4c8b-afe8-b170da53ea4b)

This is the script I use in the video : 
```bash
#!/bin/sh 
# select a file for liquidsfz 
dir="$HOME/.local/sfz" 
f=$(find $dir | cut -d/ -f6- | grep -E "\.(sfz|xml)$"| rofi -dmenu -i)  # rofi can be replaced by dmenu/fzf or anything equivalent
echo "$dir/$f" 
```
Hopefully you'll find this useful,

Thanks for the hard work and take care